### PR TITLE
Update README.md

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -502,7 +502,7 @@ Find the kesPeriod by dividing the slot tip number by the slotsPerKESPeriod.
 ```bash
 kesPeriod=$((${slotNo} / ${slotsPerKESPeriod}))
 echo kesPeriod: ${kesPeriod}
-startKesPeriod=$(( ${kesPeriod} - 1 ))
+startKesPeriod=$(( ${kesPeriod} - 0 ))
 echo startKesPeriod: ${startKesPeriod}
 ```
 {% endtab %}
@@ -2879,7 +2879,7 @@ cd $NODE_HOME
 slotNo=$(cardano-cli shelley query tip --mainnet | jq -r '.slotNo')
 slotsPerKESPeriod=$(cat $NODE_HOME/${NODE_CONFIG}-shelley-genesis.json | jq -r '.slotsPerKESPeriod')
 kesPeriod=$((${slotNo} / ${slotsPerKESPeriod}))
-startKesPeriod=$(( ${kesPeriod} - 1 ))
+startKesPeriod=$(( ${kesPeriod} - 0 ))
 echo startKesPeriod: ${startKesPeriod}
 ```
 {% endtab %}


### PR DESCRIPTION
mentioned that for v1.19.1, we should subtract 1 when calculating the KES period. This made the minted blocks invalid with error: counterTooSmallOCERT. Blocks were minted normally again when we exlcuded (kesPeriod-1) from the calculation.