### PR TITLE
Minting of invalid blocks: counterTooSmallOCERT

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -502,7 +502,7 @@ Find the kesPeriod by dividing the slot tip number by the slotsPerKESPeriod.
 ```bash
 kesPeriod=$((${slotNo} / ${slotsPerKESPeriod}))
 echo kesPeriod: ${kesPeriod}
-startKesPeriod=$(( ${kesPeriod} - 1 ))
+startKesPeriod=$(( ${kesPeriod} ))
 echo startKesPeriod: ${startKesPeriod}
 ```
 {% endtab %}


### PR DESCRIPTION
This made the minted blocks invalid with error: counterTooSmallOCERT. Blocks were minted normally again when we exlcuded (kesPeriod-1) from the calculation.
Please consider removing this line.