### PR TITLE
Add Chainstack as ETH1 node provider

### DIFF
--- a/coins/overview-eth/guide-how-to-stake-on-eth2-with-nimbus.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2-with-nimbus.md
@@ -204,7 +204,7 @@ Ethereum 2.0 requires a connection to Ethereum 1.0 in order to monitor for 32 ET
 The subsequent steps assume you have completed the [best practices security guide](guide-or-security-best-practices-for-a-eth2-validator-beaconchain-node.md).
 {% endhint %}
 
-Your choice of either [**Infura** ](https://infura.io/)or [**Geth**](https://geth.ethereum.org/)**.** [**OpenEthereum**](https://www.parity.io/ethereum/)**,** [**Besu**](https://besu.hyperledger.org/) **or** [**Nethermind**](https://www.nethermind.io/) ****coming soon.
+Your choice of either [**Infura** ](https://infura.io/), [**Chainstack** ](https://chainstack.com/) or [**Geth**](https://geth.ethereum.org/)**.** [**OpenEthereum**](https://www.parity.io/ethereum/)**,** [**Besu**](https://besu.hyperledger.org/) **or** [**Nethermind**](https://www.nethermind.io/) ****coming soon.
 
 {% hint style="info" %}
 Currently, only **Geth and Infura** are verified to work with Nimbus.

--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet.md
@@ -216,7 +216,7 @@ The subsequent steps assume you have completed the [best practices security guid
 🛑 Do not run your processes as **ROOT** user. 😱 
 {% endhint %}
 
-Your choice of either [**OpenEthereum**](https://www.parity.io/ethereum/)**,** [**Geth**](https://geth.ethereum.org/)**,** [**Besu**](https://besu.hyperledger.org/)**,** [**Nethermind**](https://www.nethermind.io/) **or** [**Infura**](https://infura.io/)**.**
+Your choice of either [**OpenEthereum**](https://www.parity.io/ethereum/)**,** [**Geth**](https://geth.ethereum.org/)**,** [**Besu**](https://besu.hyperledger.org/)**,** [**Nethermind**](https://www.nethermind.io/), [**Infura**](https://infura.io/) **or** [**Chainstack**](https://chainstack.com/)**.**
 
 {% tabs %}
 {% tab title="OpenEthereum \(Parity\)" %}
@@ -1089,7 +1089,7 @@ EOF
 ```
 
 {% hint style="warning" %}
-Nimbus only supports websocket connections \("ws://" and "wss://"\) for the ETH1 node. Geth, OpenEthereum and Infura ETH1 nodes are verified compatible.
+Nimbus only supports websocket connections \("ws://" and "wss://"\) for the ETH1 node. Geth, OpenEthereum, Infura and Chainstack ETH1 nodes are verified compatible.
 {% endhint %}
 
 Move the unit file to `/etc/systemd/system` 
@@ -3245,7 +3245,7 @@ EOF
 ```
 
 {% hint style="warning" %}
-Nimbus only supports websocket connections \("ws://" and "wss://"\) for the ETH1 node. Geth, OpenEthereum and Infura ETH1 nodes are verified compatible.
+Nimbus only supports websocket connections \("ws://" and "wss://"\) for the ETH1 node. Geth, OpenEthereum, Infura and Chainstack ETH1 nodes are verified compatible.
 {% endhint %}
 
 Move the unit file to `/etc/systemd/system` 


### PR DESCRIPTION
Great guides. I tested your instructions with Eth1 nodes provided by Chainstack (they are Geth)
and added them as supported for diversity.