### PR TITLE
Update how-to-harden-ubuntu-server.md

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/how-to-harden-ubuntu-server.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/how-to-harden-ubuntu-server.md
@@ -169,13 +169,14 @@ ssh cardano@server.public.ip.address -p <custom port number>
 {% endtabs %}
 
 {% hint style="info" %}
-Alternatively, you might need to use the following. 
+Alternatively, you might need to use the following: 
 
 Add the `-p <port#>` flag if you used a custom SSH port.
 
 ```bash
-ssh -i <path to your SSH_key_name.pub> cardano@server.public.ip.address
+ssh -i <path to your SSH_key_name> cardano@server.public.ip.address
 ```
+Use the ssh key name without the .pub extension
 {% endhint %}
 
 ## \*\*\*\*🤖 **Update your system**


### PR DESCRIPTION
After generating SSH keys and logging in to test the new configuration, the guide says to test the configuration using key.pub -- I think this is a mistake because that's the public part of the key.  Using <ssh key>.pub results in:
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for <ssh key> are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.

Using the sshkey without pub works just fine.