### PR TITLE
Changes to Pathing and Library

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -114,6 +114,7 @@ git checkout 66f017f1
 ./configure
 make
 sudo make install
+sudo ln -s /usr/local/lib/libsodium.so.23.3.0 /usr/lib/libsodium.so.23
 ```
 
 Install Cabal.
@@ -373,7 +374,7 @@ TOPOLOGY=\${DIRECTORY}/${NODE_CONFIG}-topology.json
 DB_PATH=\${DIRECTORY}/db
 SOCKET_PATH=\${DIRECTORY}/db/socket
 CONFIG=\${DIRECTORY}/${NODE_CONFIG}-config.json
-cardano-node run --topology \${TOPOLOGY} --database-path \${DB_PATH} --socket-path \${SOCKET_PATH} --host-addr \${HOSTADDR} --port \${PORT} --config \${CONFIG}
+/usr/local/bin/cardano-node run --topology \${TOPOLOGY} --database-path \${DB_PATH} --socket-path \${SOCKET_PATH} --host-addr \${HOSTADDR} --port \${PORT} --config \${CONFIG}
 EOF
 ```
 {% endtab %}
@@ -389,7 +390,7 @@ TOPOLOGY=\${DIRECTORY}/${NODE_CONFIG}-topology.json
 DB_PATH=\${DIRECTORY}/db
 SOCKET_PATH=\${DIRECTORY}/db/socket
 CONFIG=\${DIRECTORY}/${NODE_CONFIG}-config.json
-cardano-node run --topology \${TOPOLOGY} --database-path \${DB_PATH} --socket-path \${SOCKET_PATH} --host-addr \${HOSTADDR} --port \${PORT} --config \${CONFIG}
+/usr/local/bin/cardano-node run --topology \${TOPOLOGY} --database-path \${DB_PATH} --socket-path \${SOCKET_PATH} --host-addr \${HOSTADDR} --port \${PORT} --config \${CONFIG}
 EOF
 ```
 {% endtab %}


### PR DESCRIPTION
I required these changes to make things work with systemd. The instructions listed here did not work

I would get 

`
Feb 16 16:48:53 ns513917 systemd[1]: cardano-node.service: Main process exited, code=exited, status=127/n/a
Feb 16 16:48:53 ns513917 systemd[1]: cardano-node.service: Failed with result 'exit-code'.
Feb 16 16:48:58 ns513917 systemd[1]: cardano-node.service: Service RestartSec=5s expired, scheduling restart.
Feb 16 16:48:58 ns513917 systemd[1]: cardano-node.service: Scheduled restart job, restart counter is at 470.
Feb 16 16:48:58 ns513917 systemd[1]: Stopped Cardano node service.
Feb 16 16:48:58 ns513917 systemd[1]: Started Cardano node service.
Feb 16 16:48:58 ns513917 bash[20018]: /usr/local/bin/cardano-node: error while loading shared libraries: libsodium.so.23: cannot open shared object f
ile: No such file or directory
`

`
Feb 16 16:07:57 ns513917 systemd[1]: cardano-node.service: Main process exited, code=exited, status=127/n/a
Feb 16 16:07:57 ns513917 systemd[1]: cardano-node.service: Failed with result 'exit-code'.
Feb 16 16:08:02 ns513917 systemd[1]: cardano-node.service: Service RestartSec=5s expired, scheduling restart.
Feb 16 16:08:02 ns513917 systemd[1]: cardano-node.service: Scheduled restart job, restart counter is at 2.
Feb 16 16:08:02 ns513917 systemd[1]: Stopped Cardano node service.
Feb 16 16:08:02 ns513917 systemd[1]: Started Cardano node service.
Feb 16 16:08:02 ns513917 bash[4554]: /home/debian/cardano-my-node/startRelayNode1.sh: line 9: cardano-node: command not found
`