### PR TITLE
qcpolsendmytip.sh updated for cardano-node 1.26.1

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -3216,7 +3216,7 @@ sed -i -e 's/\r$//' qcpolsendmytip.sh
 md5sum qcpolsendmytip.sh
 ```
 
-To make sure the file is genuine, the md5 hash should be `d3118127e917bfbd45f642a0786a2241`. If it's not, stop here and delete the file with `rm qcpolsendmytip.sh`.
+To make sure the file is genuine, the md5 hash should be `f7646132e922b24b140202e5f5cba3ac`. If it's not, stop here and delete the file with `rm qcpolsendmytip.sh`.
 
 You will need your pooltool.io API key \(shown in your profile after registering\).
 


### PR DESCRIPTION
`cardano-cli query tip --mainnet` changed:

- `slotNo` -> `slot`
- `headerHash` -> `hash`
- `blockNo` -> `block`