### PR TITLE
Change env var keyDeposit to stakeAddressDeposit for 1.26.1

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -1208,19 +1208,19 @@ echo Number of UTXOs: ${txcnt}
 {% endtab %}
 {% endtabs %}
 
-Find the keyDeposit value.
+Find the stakeAddressDeposit value.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-keyDeposit=$(cat $NODE_HOME/params.json | jq -r '.keyDeposit')
-echo keyDeposit: $keyDeposit
+stakeAddressDeposit=$(cat $NODE_HOME/params.json | jq -r '.stakeAddressDeposit')
+echo stakeAddressDeposit: $stakeAddressDeposit
 ```
 {% endtab %}
 {% endtabs %}
 
 {% hint style="info" %}
-Registration of a stake address certificate \(keyDeposit\) costs 2000000 lovelace.
+Registration of a stake address certificate \(stakeAddressDeposit\) costs 2000000 lovelace.
 {% endhint %}
 
 Run the build-raw transaction command
@@ -1262,7 +1262,7 @@ echo fee: $fee
 {% endtabs %}
 
 {% hint style="info" %}
-Ensure your balance is greater than cost of fee + keyDeposit or this will not work.
+Ensure your balance is greater than cost of fee + stakeAddressDeposit or this will not work.
 {% endhint %}
 
 Calculate your change output.
@@ -1270,7 +1270,7 @@ Calculate your change output.
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-txOut=$((${total_balance}-${keyDeposit}-${fee}))
+txOut=$((${total_balance}-${stakeAddressDeposit}-${fee}))
 echo Change Output: ${txOut}
 ```
 {% endtab %}


### PR DESCRIPTION
protocol-parameters for cardano-cli v.1.26.x changed "keyDeposit" to "stakeAddressDeposit." This PR updates the guide to reflect that change.