### PR TITLE
Update README.md

### DIFF
--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/README.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/README.md
@@ -1190,7 +1190,7 @@ mkdir ~/git
 cd ~/git
 git clone https://github.com/status-im/nimbus-eth2
 cd nimbus-eth2
-make NIMFLAGS="-d:insecure" nimbus_beacon_node
+make nimbus_beacon_node
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
Nimbus: No longer need to compile with `insecure` to enable metrics