### PR TITLE
Update how-to-monitor-security-with-ossec.md

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/how-to-monitor-security-with-ossec.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/how-to-monitor-security-with-ossec.md
@@ -307,7 +307,7 @@ and add these lines at the end of the commands section
     <name>ossec-slack</name>
     <executable>ossec-slack.sh</executable>
     <expect></expect> <!-- no expect args required -->
-    <timeout_allowed>no<timeout_allowed>
+    <timeout_allowed>no</timeout_allowed>
   </command>  
 
   <active-response>


### PR DESCRIPTION
Missing the closing slash in the config file.
I tried to use this guide and it failed due to the missing /