### PR TITLE
Wrong NWMAGIC in topologyUpdater.sh

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -1730,7 +1730,7 @@ NETWORKID=\$(jq -r .networkId \$GENESIS_JSON)
 CNODE_VALENCY=1   # optional for multi-IP hostnames
 NWMAGIC=\$(jq -r .networkMagic < \$GENESIS_JSON)
 [[ "\${NETWORKID}" = "Mainnet" ]] && HASH_IDENTIFIER="--mainnet" || HASH_IDENTIFIER="--testnet-magic \${NWMAGIC}"
-[[ "\${NWMAGIC}" = "1097911063" ]] && NETWORK_IDENTIFIER="--mainnet" || NETWORK_IDENTIFIER="--testnet-magic \${NWMAGIC}"
+[[ "\${NWMAGIC}" = "764824073" ]] && NETWORK_IDENTIFIER="--mainnet" || NETWORK_IDENTIFIER="--testnet-magic \${NWMAGIC}"
  
 export PATH="\${CNODE_BIN}:\${PATH}"
 export CARDANO_NODE_SOCKET_PATH="\${CNODE_HOME}/db/socket"


### PR DESCRIPTION
The NWMAGIC value in the script is for testnet and makes the script use wrong NETWORK_IDENTIFIER on mainnet.