### PR TITLE
Clarify that poolMetaDataHash.txt must be copied

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -1449,6 +1449,8 @@ to be run on your air-gapped offline machine appropriately.
 **metadata-url** must be no longer than 64 characters.
 {% endhint %}
 
+Copy **poolMetaDataHash.txt** to your **air-gapped offline machine.**
+
 {% tabs %}
 {% tab title="air-gapped offline machine" %}
 ```bash


### PR DESCRIPTION
I've added text to clarify that the poolMetaDataHash.txt must be copied to the air-gapped offline machine.