### PR TITLE
Cardano - Section 18.14 - Corrected node witness node.skey

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -3764,7 +3764,7 @@ Create a witness using node.skey,
 ```bash
 cardano-cli transaction witness \
   --tx-body-file tx-pool.raw \
-  --signing-key-file node.skey \
+  --signing-key-file $HOME/cold-keys/node.skey \
   --mainnet \
   --out-file node.witness
 ```
@@ -3824,9 +3824,9 @@ cardano-cli transaction assemble \
   --tx-body-file tx-pool.raw \
   --witness-file node.witness \
   --witness-file stake.witness \
-  --witness-file payment.witness \  
+  --witness-file payment.witness \
   --witness-file hw-stake.witness \
-  --out-file tx-pool.multisign 
+  --out-file tx-pool.multisign
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
1. node.skey is stored in cold storage folder throughout the article.
2. Removed whitespace that breaks a command later one.