### PR TITLE
Fix Prometheus configs so they work in Grafana

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/16.-setup-prometheus-and-grafana-dashboard.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/16.-setup-prometheus-and-grafana-dashboard.md
@@ -92,7 +92,13 @@ scrape_configs:
 
     static_configs:
       - targets: ['localhost:9100']
+        labels:
+          alias: 'relaynode1'
+          type:  'cardano-node'
       - targets: ['<block producer ip address>:9100']
+        labels:
+          alias: 'block-producer-node'
+          type:  'cardano-node'
       - targets: ['<block producer ip address>:12798']
         labels:
           alias: 'block-producer-node'


### PR DESCRIPTION
The configs provided for Prometheus don't work out-of-the-box with the Grafana dashboards provided.  The labels need to be assigned to each of the scrape targets.