### PR TITLE
Incorporate revisions for upgrading to Cardano Node v1.35.0

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-cabal-and-ghc.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-cabal-and-ghc.md
@@ -30,6 +30,23 @@ make
 sudo make install
 ```
 
+<a name="Installsecp256k1"></a>Install libsecp256k1
+
+```bash
+cd $HOME/git
+git clone https://github.com/bitcoin-core/secp256k1
+cd secp256k1
+git checkout ac83be33
+./autogen.sh
+./configure --enable-module-schnorrsig --enable-experimental
+make
+make check
+sudo make install
+```
+
+<!--Reference:
+https://github.com/input-output-hk/cardano-node/pull/3796/files -->
+
 {% hint style="info" %}
 **Debian OS pool operators**: extra lib linking may be required.
 
@@ -37,7 +54,7 @@ sudo make install
 sudo ln -s /usr/local/lib/libsodium.so.23.3.0 /usr/lib/libsodium.so.23
 ```
 
-**AWS Linux CentOS pool operators**: clearing the lib cache may be required.
+**AWS Linux CentOS or Ubuntu pool operators**: clearing the lib cache may be required.
 
 ```bash
 sudo ldconfig

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
@@ -182,7 +182,7 @@ If you want to download new configuration files using the command line, then nav
 ## <a name="BuildingCN"></a>:zap:Building Cardano Node Binaries
 
 {% hint style="danger" %}
-Prior to building Cardano Node v1.35.0 binaries, [install libsecp256k1](../part-i-installation/installing-cabal-and-ghc.md#Installsecp256k1), and then type `sudo ldconfig`
+Prior to building Cardano Node 1.35.0 binaries, [install libsecp256k1](../part-i-installation/installing-cabal-and-ghc.md#Installsecp256k1), and then type `sudo ldconfig`
 {% endhint %}
 
 **To build binaries for a new Cardano Node version:**

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
@@ -104,9 +104,14 @@ For each Cardano Node release, Input-Output recommends compiling binaries using 
 
 _Table 1 Current Cardano Node Version Requirements_
 
+<!--
 |  Release Date  |  Cardano Node Version  |  GHC Version   | Cabal Version  |
 |:--------------:|:----------------------:|:--------------:|:--------------:|
-|  March 7, 2022 |         1.34.1         |     8.10.7     |    3.6.2.0     |
+|  March 7, 2022 |         1.34.1         |     8.10.7     |    3.6.2.0     | -->
+
+|  Release Date  |  Cardano Node Version  |  GHC Version   | Cabal Version  |
+|:--------------:|:----------------------:|:--------------:|:--------------:|
+|  June 25, 2022 |         1.35.0         |     8.10.7     |    3.6.2.0     |
 
 **To upgrade the GHCup installer for GHC and Cabal to the latest version:**
 
@@ -175,6 +180,10 @@ If you want to download new configuration files using the command line, then nav
 5. Using [`diff`](https://www.man7.org/linux/man-pages/man1/diff.1.html) or a similar file comparison utility, identify and copy customizations as needed from the backup configuration files that you created in step 2 to each new configuration file that you downloaded in step 4.
 
 ## <a name="BuildingCN"></a>:zap:Building Cardano Node Binaries
+
+{% hint style="danger" %}
+Prior to building Cardano Node v1.35.0 binaries, [install libsecp256k1](../part-i-installation/installing-cabal-and-ghc.md#Installsecp256k1), and then type `sudo ldconfig`
+{% endhint %}
 
 **To build binaries for a new Cardano Node version:**
 


### PR DESCRIPTION
Add instructions for installing the libsecp256k1 library as per the new requirement described at https://github.com/input-output-hk/cardano-node/pull/3796/files