### PR TITLE
Updated to Java V18 for Teku/Besu

### DIFF
--- a/coins/overview-eth/guide-how-to-stake-on-eth2-with-lighthouse.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2-with-lighthouse.md
@@ -318,7 +318,7 @@ sudo systemctl start eth1
 :dna: **Install java dependency.**
 
 ```
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-18-jdk
 ```
 
 :last\_quarter\_moon\_with\_face: **Download and unzip Besu.**

--- a/coins/overview-eth/guide-how-to-stake-on-eth2-with-lodestar.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2-with-lodestar.md
@@ -126,7 +126,7 @@ geth --goerli --datadir="$HOME/Goerli" --rpc
 #### :dna: Install java dependency.
 
 ```
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-18-jdk
 ```
 
 #### :last\_quarter\_moon\_with\_face: Download and unzip Besu.

--- a/coins/overview-eth/guide-how-to-stake-on-eth2-with-nimbus.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2-with-nimbus.md
@@ -352,7 +352,7 @@ sudo systemctl start eth1
 #### 🧬 Install java dependency.
 
 ```
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-18-jdk
 ```
 
 #### 🌜 Download and unzip Besu.

--- a/coins/overview-eth/guide-how-to-stake-on-eth2-with-teku-on-ubuntu.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2-with-teku-on-ubuntu.md
@@ -331,7 +331,7 @@ sudo systemctl start eth1
 #### :dna: Install java dependency.
 
 ```
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-18-jdk
 ```
 
 #### :last\_quarter\_moon\_with\_face: Download and unzip Besu.
@@ -462,13 +462,13 @@ Install git.
 sudo apt-get install git -y
 ```
 
-Install Java 11.
+Install Java 18.
 
 {% tabs %}
 {% tab title="Ubuntu 20.x" %}
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-18-jdk
 ```
 {% endtab %}
 

--- a/coins/overview-eth/guide-how-to-stake-on-eth2.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2.md
@@ -327,7 +327,7 @@ sudo systemctl start eth1
 #### 🧬 Install java dependency.
 
 ```
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-18-jdk
 ```
 
 #### 🌜 Download and unzip Besu.

--- a/coins/overview-eth/guide-or-besu-+-lodestar-or-most-viable-diverse-client-or-staking-ethereum-on-kiln-testnet.md
+++ b/coins/overview-eth/guide-or-besu-+-lodestar-or-most-viable-diverse-client-or-staking-ethereum-on-kiln-testnet.md
@@ -171,7 +171,7 @@ Setup your execution layer client, **Besu.**
 Install dependencies.
 
 ```bash
-sudo apt install openjdk-11-jdk libsodium23 libnss3 -y
+sudo apt install openjdk-18-jdk libsodium23 libnss3 -y
 ```
 
 Build the binaries.
@@ -465,7 +465,8 @@ Use the [Kiln Testnet faucet](https://faucet.kiln.themerge.dev/) to acquire some
 {% hint style="info" %}
 Alternative kiln testnet faucets:&#x20;
 
-* [https://faucet.kiln.ethdevops.io/  ](https://faucet.kiln.ethdevops.io/http://kiln-faucet.pk-net.net/)
+* [https://faucet.kiln.ethdevops.io/
+  ](https://faucet.kiln.ethdevops.io/http://kiln-faucet.pk-net.net/)
 * [http://kiln-faucet.pk-net.net/](https://faucet.kiln.ethdevops.io/http://kiln-faucet.pk-net.net/)
 {% endhint %}
 

--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet.md
@@ -471,7 +471,7 @@ sudo systemctl start eth1
 
 ```text
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
 #### 🌜 Download and unzip Besu
@@ -1260,13 +1260,13 @@ Install git.
 sudo apt-get install git -y
 ```
 
-Install Java 11.
+Install Java 18.
 
 For **Ubuntu 20.x**, use the following
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
 For **Ubuntu 18.x**, use the following
@@ -1277,7 +1277,7 @@ sudo apt update
 sudo apt install oracle-java11-set-default -y
 ```
 
-Verify Java 11+ is installed.
+Verify Java 18+ is installed.
 
 ```bash
 java --version

--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/configuring-consensus-client-beaconchain-and-validator.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/configuring-consensus-client-beaconchain-and-validator.md
@@ -611,16 +611,16 @@ Install git.
 sudo apt-get install git -y
 ```
 
-Install Java 11.
+Install Java 18.
 
 For **Ubuntu 20.x**, use the following
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
-Verify Java 11+ is installed.
+Verify Java 18+ is installed.
 
 ```bash
 java --version

--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/installing-execution-client.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/installing-execution-client.md
@@ -105,7 +105,7 @@ sudo systemctl start eth1
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
 

--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater.md
@@ -564,7 +564,7 @@ sudo systemctl start eth1
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
 
@@ -1755,18 +1755,18 @@ sudo apt-get install git -y
 
 
 
-Install Java 11.
+Install Java 18.
 
 For **Ubuntu 20.x**, use the following
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
 
 
-Verify Java 11+ is installed.
+Verify Java 18+ is installed.
 
 ```bash
 java --version

--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet.md
@@ -496,7 +496,7 @@ sudo systemctl start eth1
 
 ```
 sudo apt-get update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
 #### :last\_quarter\_moon\_with\_face: Download and unzip Besu
@@ -1337,13 +1337,13 @@ Install git.
 sudo apt-get install git -y
 ```
 
-Install Java 11.
+Install Java 18.
 
 For **Ubuntu 20.x**, use the following
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
 For **Ubuntu 18.x**, use the following
@@ -1354,7 +1354,7 @@ sudo apt update
 sudo apt install oracle-java11-set-default -y
 ```
 
-Verify Java 11+ is installed.
+Verify Java 18+ is installed.
 
 ```bash
 java --version

--- a/coins/overview-eth/guide-or-operation-client-diversity-migrate-prysm-to-teku.md
+++ b/coins/overview-eth/guide-or-operation-client-diversity-migrate-prysm-to-teku.md
@@ -42,14 +42,14 @@ Install git.
 sudo apt-get install git -y
 ```
 
-Install Java 11 for **Ubuntu 20.x**
+Install Java 18 for **Ubuntu 20.x**
 
 ```
 sudo apt update
-sudo apt install openjdk-11-jdk -y
+sudo apt install openjdk-18-jdk -y
 ```
 
-Verify Java 11+ is installed.
+Verify Java 18+ is installed.
 
 ```
 java --version


### PR DESCRIPTION
- Besu explicitely [recommends at least V17](https://besu.hyperledger.org/en/stable/HowTo/Get-Started/Installation-Options/Install-Binaries/#macos-with-homebrew:~:text=Java%2011%2B.%20We%20recommend%20using%20at%20least%20Java%2017)
- Teku asks for >=11