### PR TITLE
Update updating-stake-pool-information.md

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
@@ -142,7 +142,7 @@ The **invalid-hereafter** value must be greater than the current tip. In this ex
 cardano-cli transaction build-raw \
     ${tx_in} \
     --tx-out $(cat payment.addr)+${total_balance} \
-    --invalid-hereafter $(( ${currentSlot} + 10000)) \
+    --invalid-hereafter $((${currentSlot}+10000)) \
     --fee 0 \
     --certificate-file pool.cert \
     --certificate-file deleg.cert \
@@ -188,7 +188,7 @@ Build the transaction.
 cardano-cli transaction build-raw \
     ${tx_in} \
     --tx-out $(cat payment.addr)+${txOut} \
-    --invalid-hereafter $(( ${currentSlot} + 10000)) \
+    --invalid-hereafter $((${currentSlot}+10000)) \
     --fee ${fee} \
     --certificate-file pool.cert \
     --certificate-file deleg.cert \


### PR DESCRIPTION
Fixes errors like the one below when submitting transactions.
$ cardano-cli transaction submit \

>     --tx-file tx.signed \

>     --mainnet

Command failed: transaction submit  Error: Error while submitting tx: ShelleyTxValidationError ShelleyBasedEraAlonzo (ApplyTxError [UtxowFailure (WrappedShelleyEraFailure (UtxoFailure (OutsideValidityIntervalUTxO (ValidityInterval {invalidBefore = SNothing, invalidHereafter = SJust (SlotNo 10000)}) (SlotNo 69213233))))])