### PR TITLE
fix: fix geth prune command

### DIFF
--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-ii-maintenance/pruning-the-execution-client-to-free-up-disk-space.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-ii-maintenance/pruning-the-execution-client-to-free-up-disk-space.md
@@ -47,7 +47,7 @@ sudo service eth1 stop
 {% tabs %}
 {% tab title="Geth" %}
 ```bash
-/usr/bin/geth --datadir $HOME/.ethereum snapshot prune-state
+/usr/bin/geth snapshot prune-state --datadir $HOME/.ethereum
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The command for prune was wrong, variables like datadir have to be after commands (snapshot prune-state).
I used the command you wrote and geth returned “invalid command”.
Now I corrected it, switching commands and variables.