### PR TITLE
Note for 18089

### DIFF
--- a/coins/overview-xmr/guide-or-how-to-run-a-full-node.md
+++ b/coins/overview-xmr/guide-or-how-to-run-a-full-node.md
@@ -41,7 +41,7 @@ As of early 2021, a pruned node uses 32GB and a full node uses 96GB of storage s
 
 ![Kudos to r/Krakataua314](../../.gitbook/assets/10iwbu47ul761.png)
 
-Full Public Node with port 18089, a restricted RPC port.
+Full Public Node with port 18089, a restricted RPC port, UNLIKE the graphic above, since you must open port 18089 as well (or instead of 18081).
 
 ```bash
 # By default, deny all incoming and outgoing traffic


### PR DESCRIPTION
I don't like this solution.  A better one is to update the graphic to show port 18081/18089, and add a section about how one ought to choose between the two, or, perhaps, use the default (18081) for unrestricted local access (127.0.0.1) and 18089 for restricted public access.  In fact, given the default use of 18081 for unrestricted rpc access, I think the graphic is dangerous.