### PR TITLE
Witness with cardano-hw-cli option deprecated

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
@@ -249,7 +249,7 @@ Create a witness using hw-stake.hwsfile
 {% tab title="local PC or block producer node" %}
 ```
 cardano-hw-cli transaction witness \
-  --tx-body-file tx-pool.raw \
+  --tx-file tx-pool.raw \
   --hw-signing-file hw-stake.hwsfile \
   --mainnet \
   --out-file hw-stake.witness


### PR DESCRIPTION
Option --tx-body-file is deprecated, changed with new option --tx-file.

Check for official documentation: https://github.com/vacuumlabs/cardano-hw-cli cardano-hw-cli transaction witness
--tx-body-file FILE                    Input filepath of the TxBody. Warning! This option is DEPRECATED and will be REMOVED in Oct 2022. Please use --tx-file instead.
--tx-file FILE                         Input filepath of the tx. Use --cddl-format when building transactions with cardano-cli.