### PR TITLE
Update finding UTXOs to ignore native tokens

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
@@ -52,16 +52,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
@@ -203,16 +203,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
@@ -110,16 +110,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/claiming-stake-pool-rewards.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/claiming-stake-pool-rewards.md
@@ -57,16 +57,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 
 withdrawalString="$(cat stake.addr)+${rewardBalance}"

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
@@ -35,16 +35,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 
@@ -171,16 +175,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/retiring-your-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/retiring-your-stake-pool.md
@@ -92,16 +92,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
@@ -115,16 +115,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-v-tips/submitting-a-simple-transaction.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-v-tips/submitting-a-simple-transaction.md
@@ -55,16 +55,20 @@ cat balance.out
 tx_in=""
 total_balance=0
 while read -r utxo; do
-    in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-    idx=$(awk '{ print $2 }' <<< "${utxo}")
-    utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    total_balance=$((${total_balance}+${utxo_balance}))
-    echo TxHash: ${in_addr}#${idx}
-    echo ADA: ${utxo_balance}
-    tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    type=$(awk '{ print $6 }' <<< "${utxo}")
+    if [[ ${type} == 'TxOutDatumNone' ]]
+    then
+        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
+        idx=$(awk '{ print $2 }' <<< "${utxo}")
+        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo TxHash: ${in_addr}#${idx}
+        echo ADA: ${utxo_balance}
+        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+    fi
 done < balance.out
 txcnt=$(cat balance.out | wc -l)
-echo Total ADA balance: ${total_balance}
+echo Total available ADA balance: ${total_balance}
 echo Number of UTXOs: ${txcnt}
 ```
 {% endtab %}


### PR DESCRIPTION
Resolves issue #168 Error when using UTXO loop for available ADA
The current loop that retrieves all the available ADA is using every UTXO. Some UTXOs are native tokens (NFTs) and should not be considered in the tx_in. If they are used in the tx_in they also need to be added to the tx_out, causing unnecessary sending/receiving, also complicating the script wildly. If this solution is not acceptable, then we could consider not using a loop, and simply taking the first UTXO, then later checking if the balance is enough after adding the fee. 