### PR TITLE
Update registering-your-stake-pool.md

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
@@ -3,7 +3,7 @@
 Create your pool's metadata with a JSON file. Update with your pool information.
 
 {% hint style="warning" %}
-**ticker** must be between 3-9 characters in length. Characters must be A-Z and 0-9 only.
+**ticker** must be between 3-5 characters in length. Characters must be A-Z and 0-9 only.
 {% endhint %}
 
 {% hint style="warning" %}


### PR DESCRIPTION
Ticker is currently limited to between 3 and 5 characters. I tried to use 8 and was greeted with this message.

Command failed: stake-pool metadata-hash  Error: Error validating stake pool metadata: Error in $: "ticker" must have at least 3 and at most 5 characters, but it has 8 characters.