### PR TITLE
Update Supported Cabal Version

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
@@ -8,7 +8,7 @@ _Table 1 Current Cardano Node Version Requirements_
 
 | Release Date | Cardano Node Version | GHC Version | Cabal Version |
 | :----------: | :------------------: | :---------: | :-----------: |
-|  May 9, 2023 |         8.0.0        |    8.10.7   |    3.6.2.0    |
+|  May 9, 2023 |         8.0.0        |    8.10.7   |    3.8.1.0    |
 
 **To install GHC and Cabal:**
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
@@ -115,7 +115,7 @@ _Table 1 Current Cardano Node Version Requirements_
 
 | Release Date | Cardano Node Version | GHC Version | Cabal Version |
 | :----------: | :------------------: | :---------: | :-----------: |
-|  May 9, 2023 |         8.0.0        |    8.10.7   |    3.6.2.0    |
+|  May 9, 2023 |         8.0.0        |    8.10.7   |    3.8.1.0    |
 
 **To upgrade the GHCup installer for GHC and Cabal to the latest version:**
 


### PR DESCRIPTION
Updated to reflect the supported Cabal version for Cardano Node 8.0.0 as stated at https://github.com/input-output-hk/cardano-node/releases