### PR TITLE
Fix mistake in besu update instructions

### DIFF
--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-ii-maintenance/updating-your-execution-client.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-ii-maintenance/updating-your-execution-client.md
@@ -73,7 +73,7 @@ java -version
 Run the following to automatically download the latest linux release, un-tar and cleanup.
 
 ```bash
-BINARIES_URL="$(curl -s https://api.github.com/repos/hyperledger/besu/releases/latest | grep -o 'https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/.*tar.gz' | sed -e 's/.*\\n\(https.*.tar.gz$\)/\1/')"
+BINARIES_URL="$(curl -s https://api.github.com/repos/hyperledger/besu/releases/latest | grep -o 'https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/.*tar.gz' | sed -e 's/.*\\n\(https.*.tar.gz$\)/\1/')"
 
 echo Downloading URL: $BINARIES_URL
 


### PR DESCRIPTION
Identified by a member of the [Ethstaker discord](https://discord.com/channels/694822223575384095/1024252465148874783/1123853696363663400).

Besu binaries are stored in the `artifactory` directory, not `hyperledger`.