### PR TITLE
Update setting-up-validator-keys.md

### DIFF
--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater/step-5-installing-validator/setting-up-validator-keys.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater/step-5-installing-validator/setting-up-validator-keys.md
@@ -123,8 +123,7 @@ sudo apt install python3-pip git -y
 Download source code and install.
 
 ```bash
-mkdir -p ~/git
-cd ~/git
+cd ~
 git clone https://github.com/ethereum/staking-deposit-cli
 cd staking-deposit-cli
 sudo ./deposit.sh install


### PR DESCRIPTION
Changing this back -- I thought it made sense to use the ~/git directory if building from source (as we do the execution and consensus clients) but as the validator keys are referenced later on when configuring the validator it makes sense to pull the repo in ~ so the location is the same whether building or downloading.

Hope that makes sense and sorry for the flaff.