### PR TITLE
add jq as dependency for installing lighthouse consensus client

### DIFF
--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater/step-4-installing-consensus-client/lighthouse.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater/step-4-installing-consensus-client/lighthouse.md
@@ -28,7 +28,7 @@ Install dependencies.
 
 ```bash
 sudo apt install curl -y
-sudo apt install jq
+sudo apt install jq -y
 ```
 
 ### 2. Install Binaries

--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater/step-4-installing-consensus-client/lighthouse.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-testnet-prater/step-4-installing-consensus-client/lighthouse.md
@@ -28,6 +28,7 @@ Install dependencies.
 
 ```bash
 sudo apt install curl -y
+sudo apt install jq
 ```
 
 ### 2. Install Binaries


### PR DESCRIPTION
jq was missing on my fresh ubuntu 22.04 install 