### PR TITLE
Fix Geth config for Prometheus in Eth staking server documentation

### DIFF
--- a/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/monitoring-your-validator-with-grafana-and-prometheus.md
+++ b/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/monitoring-your-validator-with-grafana-and-prometheus.md
@@ -182,10 +182,10 @@ Append the applicable job snippet for your execution client to the end of **prom
    - job_name: 'geth'
      scrape_interval: 15s
      scrape_timeout: 10s
-     metrics_path: /debug/metrics
+     metrics_path: /debug/metrics/prometheus
      scheme: http
      static_configs:
-     - targets: ['localhost:6060']
+       - targets: ['localhost:6060']
 ```
 {% endtab %}
 


### PR DESCRIPTION
The configuration in the file is not working. The metrics path is wrong, now Geth has a metrics url for Prometheus. The second fix is an indent. I've just used this configuration and it's working, unlike that one before.