### PR TITLE
chore: fix typos

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/credits.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/credits.md
@@ -16,7 +16,7 @@ Thank you for supporting Cardano and us! Please use the below cointr.ee link. :b
 
 ## :grin: Thank You
 
-Thanks to all 102,000+ of you, the Cardano hodlers, buidlers, stakers, and pool operators for making the better future a reality.
+Thanks to all 102,000+ of you, the Cardano hodlers, builders, stakers, and pool operators for making the better future a reality.
 
 ## :sparkles: Contributors
 


### PR DESCRIPTION
fix a typo: `buidlers`->`builders`