### PR TITLE
Update compiling-cardano-node.md

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/compiling-cardano-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/compiling-cardano-node.md
@@ -35,13 +35,6 @@ cabal update
 cabal configure -O0 -w ghc-<GHCVersionNumber>
 ```
 
-1. Using a text editor, open the file named `cabal.project.local` located in the current folder, and then add the following lines at the end of the file to avoid installing a custom libsodium library:
-
-```bash
-package cardano-crypto-praos
- flags: -external-libsodium-vrf
-```
-
 1. Save and close the `cabal.project.local` file.
 2. To produce executable `cardano-node` and `cardano-cli` binaries, type:
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/compiling-cardano-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/compiling-cardano-node.md
@@ -35,8 +35,7 @@ cabal update
 cabal configure -O0 -w ghc-<GHCVersionNumber>
 ```
 
-1. Save and close the `cabal.project.local` file.
-2. To produce executable `cardano-node` and `cardano-cli` binaries, type:
+1. To produce executable `cardano-node` and `cardano-cli` binaries, type:
 
 ```bash
 cabal build cardano-node cardano-cli


### PR DESCRIPTION
Removed the -external-libsodium-praos flag, as that is no longer recommended for the production environment, only for development. https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/getting-started/install.md https://forum.cardano.org/t/some-thoughts-concerning-the-node-build-process/129641