### PR TITLE
Address Issue #251

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
@@ -18,6 +18,7 @@ Create a certificate, `stake.cert`, using the `stake.vkey`
 ```
 cardano-cli conway stake-address registration-certificate \
     --stake-verification-key-file stake.vkey \
+	--key-reg-deposit-amt 2000000 \
     --out-file stake.cert
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-representative.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-representative.md
@@ -29,7 +29,7 @@ Create a certificate, `vote-deleg.cert`, using the `stake.vkey`
 To delegate your voting power to a DRep, type the following command where `<DRepID>` is the ID of the DRep receiving your delegation:
 
 ```
-cardano-cli conway stake-address registration-certificate \
+cardano-cli conway stake-address vote-delegation-certificate \
     --stake-verification-key-file stake.vkey \
     --drep-key-hash <DRepID> \
     --out-file vote-deleg.cert
@@ -40,7 +40,7 @@ cardano-cli conway stake-address registration-certificate \
 To opt out of the governance process, type:
 
 ```
-cardano-cli conway stake-address registration-certificate \
+cardano-cli conway stake-address vote-delegation-certificate \
     --stake-verification-key-file stake.vkey \
     --always-abstain \
     --out-file vote-deleg.cert
@@ -51,7 +51,7 @@ cardano-cli conway stake-address registration-certificate \
 To vote `No` on every proposal, type:
 
 ```
-cardano-cli conway stake-address registration-certificate \
+cardano-cli conway stake-address vote-delegation-certificate \
     --stake-verification-key-file stake.vkey \
     --always-no-confidence \
     --out-file vote-deleg.cert

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
@@ -11,6 +11,7 @@ Create a certificate, `stake.cert`, using the `stake.vkey`
 ```
 cardano-cli conway stake-address registration-certificate \
     --stake-verification-key-file stake.vkey \
+	--key-reg-deposit-amt 2000000 \
     --out-file stake.cert
 ```
 


### PR DESCRIPTION
The pull request updates the *How to Set Up a Cardano Stake Pool* Guide to:

- Fix syntax for the `cardano-cli conway stake-address registration-certificate` command
- Correct errors in the *Delegating to a Representative* topic