### PR TITLE
Typo Update contributor-covenant-code-of-conduct.md

### DIFF
--- a/contributing/contributor-covenant-code-of-conduct.md
+++ b/contributing/contributor-covenant-code-of-conduct.md
@@ -2,7 +2,7 @@
 
 ### :apple: Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ### :hourglass\_flowing\_sand: Our Standards
 


### PR DESCRIPTION
**Fix Typo: "pledge to making" → "pledge to make"**

I found a grammatical error in the Contributor Covenant Code of Conduct. The phrase **"pledge to making"** should be corrected to **"pledge to make"** for proper grammatical structure.

### Corrected Version:
> In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to **make** participation in our project and our community a harassment-free experience for everyone...

This change is important for maintaining clarity and grammatical accuracy in the document, which helps to ensure professionalism and readability for all contributors.