### PR TITLE
Set CARDANO_NODE_SOCKET_PATH variable

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
@@ -157,7 +157,7 @@ sudo chmod u=rw,go=r /usr/local/{lib/{libblst.a,pkgconfig/libblst.pc},include/{b
 12\. Using a text editor, open the `$HOME/.bashrc` file, and then add the following lines at the end of the file:
 
 ```bash
-# Set environment variables so that the compiler finds libsodium on your computer
+# Set environment variables so that the compiler finds libsodium, libsecp256k1 and blst libraries on your computer
 export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 # Set an environment variable indicating the file path to configuration files and scripts
@@ -165,6 +165,8 @@ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 export NODE_HOME="$HOME/cardano-my-node"
 # Set an environment variable indicating the Cardano network cluster where your node runs
 export NODE_CONFIG="mainnet"
+# Set an environment variable indicating where the Cardano node socket file is located
+export CARDANO_NODE_SOCKET_PATH="$NODE_HOME/db/socket"
 ```
 
 {% hint style="info" %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/generating-keys-for-the-block-producing-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/generating-keys-for-the-block-producing-node.md
@@ -82,6 +82,10 @@ echo slotNo: ${slotNo}
 {% endtab %}
 {% endtabs %}
 
+{% hint style="info" %}
+The `cardano-cli conway query tip --mainnet` command uses the `CARDANO_NODE_SOCKET_PATH` environment variable that you set in the `$HOME/.bashrc` file when [Installing GHC and Cabal](../part-i-installation/installing-ghc-and-cabal.md). `cardano-cli` commands throughout the CoinCashew Guide may use the `CARDANO_NODE_SOCKET_PATH` environment variable. If you do not set the `CARDANO_NODE_SOCKET_PATH` environment variable, then you need to set the `--socket-path` option explicitly in each command requiring the location of the Cardano node socket file.
+{% endhint %}
+
 Find the kesPeriod by dividing the slot tip number by the slotsPerKESPeriod.
 
 {% tabs %}


### PR DESCRIPTION
Setting the CARDANO_NODE_SOCKET_PATH variable in .bashrc is required.