### PR TITLE
Update installing-ghc-and-cabal.md

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
@@ -39,7 +39,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 i. Press ENTER to proceed.\
 ii. To prepend the required PATH variable to `$HOME/.bashrc`, type `P`\
 iii. When prompted to install haskell-language-server (HLS), type `N`\
-iv. When prompted to install slack, type `N`\
+iv. When prompted to install stack, type `N`\
 v. Press ENTER to proceed.
 
 {% hint style="info" %}


### PR DESCRIPTION
I noticed the document said "slack" but the process actually says "stack".

From the installer:
"Do you want to enable better integration of stack with GHCup? This means that stack won't install its own GHC versions, but uses GHCup's."