### PR TITLE
Incorporate Revisions Supporting Cardano Node 10.3.1

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -52,6 +52,8 @@ To search the _How to Set Up a Cardano Stake Pool_ guide, click the magnifying g
 
 ## :page\_facing\_up: Change Log
 
+* April 26, 2025
+  * Incorporating revisions to support Cardano Node 10.3.1 and Cardano CLI 10.7.0.0
 * April 21, 2025
   * Fixing error in the [Generating Keys for the Block-producing Node](part-iii-operation/generating-keys-for-the-block-producing-node.md) topic
   * Improving general overview of Cardano network and stake pool architecture

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/compiling-cardano-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/compiling-cardano-node.md
@@ -4,13 +4,19 @@ After you finish installing GHC and Cabal successfully, you can compile Cardano 
 
 **To compile Cardano Node:**
 
-1. In a terminal window on the computer hosting your block-producing node, type the following command to navigate to the working directory that you created in the procedure [Installing Glasgow Haskell Compiler and Cabal](installing-ghc-and-cabal.md):
+1. To ensure that development headers for the `libsodium` cryptographic library are NOT installed on the local computer, type:
+
+```bash
+sudo apt remove libsodium-dev
+```
+
+2. In a terminal window on the computer hosting your block-producing node, type the following command to navigate to the working directory that you created in the procedure [Installing Glasgow Haskell Compiler and Cabal](installing-ghc-and-cabal.md):
 
 ```bash
 cd $HOME/git
 ```
 
-2. To download Cardano Node source code, type:
+3. To download Cardano Node source code, type:
 
 ```bash
 git clone https://github.com/IntersectMBO/cardano-node.git
@@ -18,7 +24,7 @@ cd cardano-node
 git fetch --all --recurse-submodules --tags
 ```
 
-3. To switch the repository that you downloaded to your local computer in step 2 to the latest tagged commit, type:
+4. To switch the repository that you downloaded to your local computer in step 3 to the latest tagged commit, type:
 
 ```bash
 git checkout $(curl -s https://api.github.com/repos/IntersectMBO/cardano-node/releases/latest | jq -r .tag_name)
@@ -28,14 +34,14 @@ git checkout $(curl -s https://api.github.com/repos/IntersectMBO/cardano-node/re
 Typing a dollar sign ("$") before a command in parentheses refers to the output of the command in parentheses. For example, using a Web browser you can navigate to the above URL https://api.github.com/repos/IntersectMBO/cardano-node/releases/latest to display the data that the `curl` command retrieves, and then confirm the value of the `tag_name` attribute that the `jq` command selects.
 {% endhint %}
 
-4. To adjust the project configuration to disable optimization and set the recommended compiler version, type the following command where `<GHCVersionNumber>` is the GHC version that you set in the procedure [Installing Glasgow Haskell Compiler and Cabal](installing-ghc-and-cabal.md):
+5. To adjust the project configuration to disable optimization and set the recommended compiler version, type the following command where `<GHCVersionNumber>` is the GHC version that you set in the procedure [Installing Glasgow Haskell Compiler and Cabal](installing-ghc-and-cabal.md):
 
 ```bash
 cabal update
 cabal configure -O0 -w ghc-<GHCVersionNumber>
 ```
 
-5. To produce executable `cardano-node` and `cardano-cli` binaries, type:
+6. To produce executable `cardano-node` and `cardano-cli` binaries, type:
 
 ```bash
 cabal build all
@@ -48,18 +54,18 @@ cabal build cardano-cli
 Depending on the processing power of your computer, the build process requires about 20 minutes to complete.
 {% endhint %}
 
-6. To copy the `cardano-node` and `cardano-cli` binaries that you produced in step 7 into the `/usr/local/bin` directory, type:
+7. To copy the `cardano-node` and `cardano-cli` binaries that you produced in step 6 into the `/usr/local/bin` directory, type:
 
 ```bash
 sudo cp -p "$(./scripts/bin-path.sh cardano-node)" /usr/local/bin/cardano-node
 sudo cp -p "$(./scripts/bin-path.sh cardano-cli)" /usr/local/bin/cardano-cli
 ```
 
-7. To confirm that the version installed on your computer matches the latest release available in the Cardano Node [GitHub repository](https://github.com/input-output-hk/cardano-node), type:
+8. To confirm that the version installed on your computer matches the latest release available in the Cardano Node [GitHub repository](https://github.com/input-output-hk/cardano-node), type:
 
 ```bash
 cardano-node --version
 cardano-cli --version
 ```
 
-8. On each computer hosting a relay or block-producing node for your stake pool, repeat steps 1 to 7
+9. On each computer hosting a relay or block-producing node for your stake pool, repeat steps 1 to 8

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
@@ -8,7 +8,7 @@ _Table 1 Current Cardano Node Version Requirements_
 
 |     Release Date     | Cardano Node Version | Cardano CLI Version | GHC Version | Cabal Version |
 |  :----------------:  | :------------------: | :-----------------: | :---------: | :-----------: |
-|     January 2025     |        10.1.4        |      10.1.1.0       |    8.10.7   |    3.8.1.0    |
+|      April 2025      |        10.3.1        |      10.7.0.0       |    9.6.7    |    3.12.1.0   |
 
 **To install GHC and Cabal:**
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
@@ -115,7 +115,7 @@ _Table 1 Current Cardano Node Version Requirements_
 
 |     Release Date     | Cardano Node Version | Cardano CLI Version | GHC Version | Cabal Version |
 |  :----------------:  | :------------------: | :-----------------: | :---------: | :-----------: |
-|     January 2025     |        10.1.4        |      10.1.1.0       |    8.10.7   |    3.8.1.0    |
+|      April 2025      |        10.3.1        |      10.7.0.0       |    9.6.7    |    3.12.1.0   |
 
 
 **To upgrade the GHCup installer for GHC and Cabal to the latest version:**
@@ -340,6 +340,8 @@ Cloning the GitHub repository to a new folder allows you to roll back the upgrad
 2\. To build Cardano Node binaries using the source code that you downloaded in step 1, type the following commands where `<NewFolderName>` is the name of the folder you created in step 1 and `<GHCVersionNumber>` is the GHC version that you set in the section [Setting GHC and Cabal Versions](upgrading-a-node.md#SetGCVersions):
 
 ```bash
+# Ensure that development headers for the libsodium cryptographic library are NOT installed on the local computer
+sudo apt remove libsodium-dev
 # Navigate to the folder where you cloned the Cardano Node repository
 cd $HOME/git/<NewFolderName>
 # Update the list of available packages


### PR DESCRIPTION
The pull request updates the guide to introduce support for Cardano Node 10.3.1

CN 10.3.1 includes the new tracing system ([Cardano Tracer](https://developers.cardano.org/docs/get-started/cardano-node/new-tracing-system/new-tracing-system/)) and [Ourboros Genesis](https://iohk.io/en/blog/posts/2023/02/09/ouroboros-genesis-enhanced-security-in-a-dynamic-environment/). Revisions do NOT explicitly discuss Cardano Tracer or Ouroboros Genesis due to the following reasons:

- In CN 10.3.1, Cardano Tracer is disabled by default. The new tracing system continues to evolve in development, and the old tracing system is enabled by default.
- Ouroborus Genesis is discussed in the CN 10.3.1 [Release Notes](https://github.com/IntersectMBO/cardano-node/releases/tag/10.3.1). Merging new keys that enable Ouroboros Genesis into the `topology.json` and `config.json` files is optional. Functionality to support synchronizing the ledger from the genesis block that shipped in prior CN releases remains unchanged in CN 10.3.1 Incidentally, Mithril seems to solve the same problem that Ouroboros Genesis solves using a different approach.