### PR TITLE
Update erigon.md -- add correct sites, small fixes.

### DIFF
--- a/coins/overview-eth/testnet-holesky-validator/step-3-installing-execution-client/erigon.md
+++ b/coins/overview-eth/testnet-holesky-validator/step-3-installing-execution-client/erigon.md
@@ -10,9 +10,9 @@
 
 | Subject       | Link                                                                                                       |
 | ------------- | ---------------------------------------------------------------------------------------------------------- |
-| Releases      | [https://github.com/ledgerwatch/erigon/releases](https://github.com/ledgerwatch/erigon/releases)           |
-| Documentation | [https://github.com/ledgerwatch/erigon#documentation](https://github.com/ledgerwatch/erigon#documentation) |
-| Website       | [https://erigon.substack.com](https://erigon.substack.com/)                                                |
+| Releases      | [https://github.com/erigontech/erigon/releases](https://github.com/erigontech/erigon/releases)           |
+| Documentation | [https://docs.erigon.tech/](https://docs.erigon.tech/) |
+| Website       | [https://erigon.tech/](https://erigon.tech/)                                                |
 
 ### 1. Initial configuration
 
@@ -42,8 +42,8 @@ sudo apt install curl libsnappy-dev libc6-dev jq libc6 unzip -y
 Run the following to automatically download the latest linux release, un-tar and cleanup.
 
 ```bash
-RELEASE_URL="https://api.github.com/repos/ledgerwatch/erigon/releases/latest"
-BINARIES_URL="$(curl -s $RELEASE_URL | jq -r ".assets[] | select(.name) | .browser_download_url" | grep linux_amd64)"
+RELEASE_URL="https://api.github.com/repos/erigontech/erigon/releases/latest"
+BINARIES_URL="$(curl -s $RELEASE_URL | jq -r ".assets[] | select(.name) | .browser_download_url" | grep linux_amd64v2)"
 
 echo Downloading URL: $BINARIES_URL
 
@@ -68,7 +68,7 @@ sudo mv $HOME/erigon /usr/local/bin/erigon
 Install Go dependencies. Latest version [available here](https://go.dev/dl/).
 
 ```bash
-wget -O go.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
+wget -O go.tar.gz https://go.dev/dl/go1.24.2.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go.tar.gz
 echo export PATH=$PATH:/usr/local/go/bin >> $HOME/.bashrc
 source $HOME/.bashrc
@@ -93,10 +93,10 @@ Build the binary.
 ```bash
 mkdir -p ~/git
 cd ~/git
-git clone https://github.com/ledgerwatch/erigon.git
+git clone https://github.com/erigontech/erigon.git
 cd erigon
 git fetch --tags
-# Get latest tag name
+# Get latest tag name or use 'main' branch (could be unstable).
 latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
 # Checkout latest tag
 git checkout $latestTag


### PR DESCRIPTION
Erigon moved to own project https://github.com/erigontech and provided detailed documentation for users.
Also by default install amd64v2 version which should be fine for most of users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for the Erigon Ethereum execution client to use new official sources and tooling.
  - Revised URLs to point to the "erigontech" organization and erigon.tech domain.
  - Updated Go version requirements and binary download filters.
  - Clarified steps for cloning and checking out the Erigon source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->