### PR TITLE
Updating GHC and Cabal dependancies to reflect more recent changes

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
@@ -22,7 +22,7 @@ sudo apt-get upgrade -y
 2\. To install packages and tools required for downloading and compiling Cardano Node source code, type:
 
 ```bash
-sudo apt-get install autoconf automake build-essential curl g++ git jq libffi-dev libgmp-dev libncursesw5 libssl-dev libsystemd-dev libtinfo-dev libtool make pkg-config tmux wget zlib1g-dev liblmdb-dev -y
+sudo apt-get install autoconf automake build-essential curl g++ git jq libffi-dev libgmp-dev libncurses-dev libssl-dev libsystemd-dev libtool make pkg-config tmux wget zlib1g-dev liblmdb-dev -y
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
Removed transitional lib dependency 'libtinfo-dev' and updated `libncursesw5` to `libncurses-dev` as `libncurses5` was removed in Ubuntu 24.04 per Cardano-portal developer issue #1364 and fix was included in Cardano-portal developer merge #1453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions by replacing `libncursesw5` with `libncurses-dev` and removing `libtinfo-dev` from the list of required packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->