### PR TITLE
Supporting Cardano Node 10.5.1

### DIFF
--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -2,7 +2,7 @@
 
 The _How to Set Up a Cardano Stake Pool_ guide explains how to install and configure a Cardano stake pool from source code on Ubuntu/Debian in a two-node setup comprised of one block-producing node and one relay node.
 
-Every Cardano stake pool requires one node configured as a block producer. For security, stake pools operating on Mainnet also implement one or more relay nodes, as illustrated in the following diagram.
+Every Cardano stake pool requires one node configured as a block producer. To preserve network security, stake pools operating on Mainnet also implement one or more relay nodes, as illustrated in the following diagram.
 
 
 ![](../../../.gitbook/assets/producer-relay-diagram.png)

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -52,6 +52,9 @@ To search the _How to Set Up a Cardano Stake Pool_ guide, click the magnifying g
 
 ## :page\_facing\_up: Change Log
 
+* August 8, 2025
+  * Incorporating revisions supporting Cardano Node 10.5.1 and Cardano CLI 10.11.0.0
+  * Fixing minor errors
 * April 26, 2025
   * Incorporating revisions to support Cardano Node 10.3.1 and Cardano CLI 10.7.0.0
 * April 21, 2025

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -54,6 +54,7 @@ To search the _How to Set Up a Cardano Stake Pool_ guide, click the magnifying g
 
 * August 8, 2025
   * Incorporating revisions supporting Cardano Node 10.5.1 and Cardano CLI 10.11.0.0
+  * Updating scripts to parse Cardano CLI JSON output
   * Revising the example DNS name used to demonstrate how to register relay nodes
   * Fixing minor errors
 * April 26, 2025

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -1,9 +1,9 @@
----
-description: >-
-  This guide explains how to install and configure a Cardano stake pool from source code on Ubuntu/Debian in a two-node setup comprised of one block-producing node and one relay node. Every Cardano stake pool requires one node configured as a block producer. For security, stake pools operating on Mainnet also implement one or more relay nodes.
----
-
 # Guide: How to Set Up a Cardano Stake Pool
+
+The _How to Set Up a Cardano Stake Pool_ guide explains how to install and configure a Cardano stake pool from source code on Ubuntu/Debian in a two-node setup comprised of one block-producing node and one relay node.
+
+Every Cardano stake pool requires one node configured as a block producer. For security, stake pools operating on Mainnet also implement one or more relay nodes, as illustrated in the following diagram.
+
 
 ![](../../../.gitbook/assets/producer-relay-diagram.png)
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/README.md
@@ -54,6 +54,7 @@ To search the _How to Set Up a Cardano Stake Pool_ guide, click the magnifying g
 
 * August 8, 2025
   * Incorporating revisions supporting Cardano Node 10.5.1 and Cardano CLI 10.11.0.0
+  * Revising the example DNS name used to demonstrate how to register relay nodes
   * Fixing minor errors
 * April 26, 2025
   * Incorporating revisions to support Cardano Node 10.3.1 and Cardano CLI 10.7.0.0

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/installing-ghc-and-cabal.md
@@ -8,7 +8,7 @@ _Table 1 Current Cardano Node Version Requirements_
 
 |     Release Date     | Cardano Node Version | Cardano CLI Version | GHC Version | Cabal Version |
 |  :----------------:  | :------------------: | :-----------------: | :---------: | :-----------: |
-|      April 2025      |        10.3.1        |      10.7.0.0       |    9.6.7    |    3.12.1.0   |
+|       July 2025      |        10.5.1        |      10.11.0.0      |    9.6.7    |    3.12.1.0   |
 
 **To install GHC and Cabal:**
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/prerequisites.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/prerequisites.md
@@ -12,7 +12,7 @@ As a Stake Pool Operator (SPO) for Cardano, you need:
 
 * Operational knowledge of how to set up, run and maintain a Cardano node continuously
 * A commitment to maintain your node 24/7/365
-* System operation skills including general knowledge of using [Bash scripts](https://linuxconfig.org/bash-scripting-tutorial-for-beginners), [JavaScript Object Notation (JSON) format](https://attacomsian.com/blog/what-is-json?msclkid=0445ae34ce4d11ec84216d09187b5112), [systemd services](https://linuxconfig.org/how-to-create-systemd-service-unit-in-linux) and [cron jobs](https://itsfoss.com/cron-job/)
+* System operation skills including general knowledge of [Linux](https://linuxjourney.com/), [Bash scripting](https://linuxconfig.org/bash-scripting-tutorial-for-beginners), [JavaScript Object Notation (JSON) format](https://attacomsian.com/blog/what-is-json?msclkid=0445ae34ce4d11ec84216d09187b5112), [systemd services](https://linuxconfig.org/how-to-create-systemd-service-unit-in-linux) and [cron jobs](https://itsfoss.com/cron-job/)
 * Server administration skills (operational and maintenance)
 * Fundamental understanding of [networking](https://www.ibm.com/cloud/learn/networking-a-complete-guide)
 
@@ -20,7 +20,7 @@ As a Stake Pool Operator (SPO) for Cardano, you need:
 
 * Experience of development and operations (DevOps)
 * Experience in how to [harden ](https://www.lifewire.com/harden-ubuntu-server-security-4178243)and [secure a server](https://gist.github.com/lokhman/cc716d2e2d373dd696b2d9264c0287a3).
-* In the [Cardano Developer Portal](https://developers.cardano.org/docs/get-started/), successfully complete the section [Operate a Stake Pool](https://developers.cardano.org/docs/operate-a-stake-pool/) including the [Stake Pool Course](https://developers.cardano.org/docs/stake-pool-course/)
+* In the [Cardano Developer Portal](https://developers.cardano.org/docs/get-started/), successfully complete the section [Operate a Stake Pool](https://developers.cardano.org/docs/operate-a-stake-pool/)
 
 {% hint style="danger" %}
 :octagonal\_sign: **Before continuing this guide, you must satisfy the above requirements**. :construction:
@@ -29,11 +29,11 @@ As a Stake Pool Operator (SPO) for Cardano, you need:
 ## :reminder\_ribbon: Minimum Mainnet Stake Pool Hardware and Operating Requirements
 
 * **Two separate servers**: 1 block producer node, 1 registered relay node
-* **One air-gapped offline machine (cold environment)**
+* **One air-gapped offline computer (cold environment)**
 * **Operating system**: 64-bit Linux (i.e. Ubuntu 22.04 LTS)
 * **Processor:** An Intel or AMD x86 processor with two or more cores, at 2GHz or faster
 * **Memory:** 24GB RAM (including swap space)
-* **Storage:** 250GB free storage
+* **Storage:** 300GB free storage
 * **Internet:** Static IP address and a broadband connection supporting speeds at least 10 Mbps
 * **Data Plan**: At least 1GB per day (30GB per month)
 * **Power:** Reliable electrical power
@@ -44,12 +44,12 @@ As a Stake Pool Operator (SPO) for Cardano, you need:
 * **Four separate servers**: 1 block producer node, 3 relay nodes (2 registered relays and 1 unregistered relay) located in at least two different physical locations around the world
 * **One air-gapped offline machine (cold environment)**
 * **Operating system**: 64-bit Linux (i.e. Ubuntu 22.04 LTS)
-* **Processor:** 4 core or higher CPU
+* **Processor:** An Intel or AMD x86 processor with four or more cores, at 2GHz or faster
 * **Memory**: 24GB+ RAM
-* **Storage**: 300GB+ free storage
+* **Storage**: 350GB+ free storage
 * **Internet**: Static IP addresses and broadband connections supporting speeds of at least 100 Mbps
 * **Data Plan**: Unlimited
-* **Power:** Reliable electrical power with UPS or other backup power source
+* **Power:** Reliable electrical power with an Uninterruptible Power Supply (UPS) or other backup power source
 * **ADA balance**: More pledge and stake is better, to be determined by **a0**, the pledge influence factor
 
 ## :hammer: Example Testnet Stake Pool Hardware and Operating Requirements
@@ -58,7 +58,7 @@ As a Stake Pool Operator (SPO) for Cardano, you need:
 * **Operating system**: 64-bit Linux (i.e. Ubuntu 22.04 LTS)
 * **Processor:** An Intel or AMD x86 processor with two or more cores, at 2GHz or faster
 * **Memory:** 8GB RAM
-* **Storage:** 25GB free storage
+* **Storage:** 50GB free storage
 * **Internet:** Static IP address and a broadband connection supporting speeds at least 10 Mbps
 * **Data Plan**: At least 1GB per day (30GB per month)
 * **Power:** Reliable electrical power
@@ -66,7 +66,7 @@ As a Stake Pool Operator (SPO) for Cardano, you need:
 
 ## :unlock: Recommended Stake Pool Security
 
-If you need ideas on how to harden your stake pool's nodes, refer to [this guide](hardening-an-ubuntu-server.md).
+If you need ideas on how to harden your stake pool's nodes, see the topic [Hardening an Ubuntu Server](hardening-an-ubuntu-server.md).
 
 ## :tools: Setup Ubuntu
 
@@ -74,4 +74,4 @@ Refer to the respective guide to [Install Ubuntu Server](https://ubuntu.com/tuto
 
 ## :bricks: Rebuilding Nodes
 
-If you are rebuilding or reusing an existing `cardano-node` installation, refer to the section [Resetting an Installation](../part-v-tips/resetting-an-installation.md).
+If you are rebuilding or reusing an existing Cardano Node installation, see the topic [Resetting an Installation](../part-v-tips/resetting-an-installation.md).

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/prerequisites.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites
 
-After completing the _How to Set Up a Cardano Stake Pool_ guide, you will know what you need to register and operate a stake pool on Mainnet. The guide also includes instructions throughout explaining how to configure a stake pool to operate in a Testnet environment.
+After completing the _How to Set Up a Cardano Stake Pool_ guide, you will know how to register and operate a secure stake pool on Mainnet. The guide also includes instructions throughout explaining how to configure a stake pool to operate in a Testnet environment.
 
 Operating a stake pool in a Cardano [Testnet Environment](https://docs.cardano.org/cardano-testnets/environments) prior to registering a stake pool in the Mainnet production environment offers a risk-free approach to start learning practically about the technical skills, commitment, responsibilities and benefits of operating a Cardano stake pool.
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/prerequisites.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-i-installation/prerequisites.md
@@ -1,10 +1,12 @@
 # Prerequisites
 
+After completing the _How to Set Up a Cardano Stake Pool_ guide, you will know what you need to register and operate a stake pool on Mainnet. The guide also includes instructions throughout explaining how to configure a stake pool to operate in a Testnet environment.
+
 Operating a stake pool in a Cardano [Testnet Environment](https://docs.cardano.org/cardano-testnets/environments) prior to registering a stake pool in the Mainnet production environment offers a risk-free approach to start learning practically about the technical skills, commitment, responsibilities and benefits of operating a Cardano stake pool.
 
-When operating a stake pool on Mainnet, using a Testnet environment to test configuration changes and upgrades as well as troubleshoot any issues that may arise without impacting the production environment is very helpful.
+If you are unsure of the Testnet environment to use to practice registering and operating a stake pool, consider using the [Preview](https://docs.cardano.org/cardano-testnets/environments#preview) testing network environment.
 
-While explaining how to implement a stake pool on Mainnet, The _How to Set Up a Cardano Stake Pool_ guide also includes instructions throughout describing how to configure a stake pool to operate in a Testnet environment.
+When operating a stake pool on Mainnet, using a Testnet environment to test configuration changes and upgrades as well as troubleshoot any issues that may arise without impacting the production environment is very helpful.
 
 ## :man\_mage: Mandatory Skills for Stake Pool Operators
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/configuring-slot-leader-calculation.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/configuring-slot-leader-calculation.md
@@ -40,17 +40,41 @@ cardano-cli conway query leadership-schedule \
 
 Example leadership schedule output:
 
-```ada
-SlotNo                          UTC Time
--------------------------------------------------------------
-     4073                   2021-12-29 17:26:54.998001755 UTC
-     4126                   2021-12-29 17:27:00.298001755 UTC
-     4206                   2021-12-29 17:27:08.298001755 UTC
-     4256                   2021-12-29 17:27:13.298001755 UTC
-     4309                   2021-12-29 17:27:18.598001755 UTC
-     4376                   2021-12-29 17:27:25.298001755 UTC
-     4423                   2021-12-29 17:27:29.998001755 UTC
-     4433                   2021-12-29 17:27:30.998001755 UTC
+```
+[
+    {
+        "slotNumber": 88241103,
+        "slotTime": "2025-08-11T07:25:03Z"
+    },
+    {
+        "slotNumber": 88242465,
+        "slotTime": "2025-08-11T07:47:45Z"
+    },
+    {
+        "slotNumber": 88254698,
+        "slotTime": "2025-08-11T11:11:38Z"
+    },
+    {
+        "slotNumber": 88267859,
+        "slotTime": "2025-08-11T14:50:59Z"
+    },
+    {
+        "slotNumber": 88280570,
+        "slotTime": "2025-08-11T18:22:50Z"
+    },
+    {
+        "slotNumber": 88281213,
+        "slotTime": "2025-08-11T18:33:33Z"
+    },
+    {
+        "slotNumber": 88283929,
+        "slotTime": "2025-08-11T19:18:49Z"
+    },
+    {
+        "slotNumber": 88292543,
+        "slotTime": "2025-08-11T21:42:23Z"
+    }
+]
 ```
 
 :repeat: **Automate the process with Cronjob:**

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
@@ -127,7 +127,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 2 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-address.md
@@ -37,37 +37,45 @@ echo Current Slot: $currentSlot
 {% endtab %}
 {% endtabs %}
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 {% endtab %}
 {% endtabs %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
@@ -278,7 +278,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 3 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/registering-your-stake-pool.md
@@ -191,37 +191,45 @@ echo Current Slot: $currentSlot
 {% endtab %}
 {% endtabs %}
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 {% endtab %}
 {% endtabs %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
@@ -94,37 +94,45 @@ echo Current Slot: $currentSlot
 {% endtab %}
 {% endtabs %}
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 {% endtab %}
 {% endtabs %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
@@ -166,7 +166,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 4 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/securing-your-stake-pool-using-a-hardware-wallet.md
@@ -66,7 +66,7 @@ cardano-cli conway stake-pool registration-certificate \
     --pool-owner-stake-verification-key-file stake.vkey \
     --pool-owner-stake-verification-key-file hw-stake.vkey \
     --mainnet \
-    --single-host-pool-relay <dns based relay, example ~ relaynode1.myadapoolnamerocks.com> \
+    --single-host-pool-relay <dns based relay, example ~ relaynode1.pool.example.net> \
     --pool-relay-port 6000 \
     --metadata-url <url where you uploaded poolMetaData.json> \
     --metadata-hash $(cat poolMetaDataHash.txt) \

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/setting-up-mithril-signer.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/setting-up-mithril-signer.md
@@ -1,12 +1,18 @@
 # Setting up a Mithril Signer
 
-The [Mithril](https://mithril.network/doc/mithril/intro/) project implements Stake-based Threshold Multisignatures on top of the Cardano network. The Mithril protocol allows individual stakeholders in the Cardano blockchain network to sign messages aggregated into a multi-signature, guaranteeing that the stakeholders represent a minimum share of the total stake.
+The [Mithril](https://mithril.network/doc/mithril/intro/) project implements Stake-based Threshold Multisignatures on the Cardano network. The Mithril protocol allows individual stakeholders in the Cardano blockchain network to sign messages aggregated into a multi-signature, guaranteeing that the stakeholders represent a minimum share of the total stake.
 
 To set up a Mithril Signer, you need to:
 
 1. Install Mithril Signer on the block-producing node for your stake pool.
 
 2. Implement [Squid](https://www.squid-cache.org/) as a forward proxy on one the relays for your stake pool.
+
+Implementing a Mithril Signer and Relay enables your stake pool to contribute to securing the integrity of Mithril snapshots available on the Cardano network.
+
+{% hint style="info" %}
+Mithril has numerous potential applications, including synchronizing data for both light and full-node wallets, as well as facilitating data exchanges with layer 2 solutions such as bridges, sidechains, rollups and state channels. For most stake pools, implementing a Mithril client to bootstrap a Cardano Node using a Mithril snapshot is not necessary.
+{% endhint %}
 
 ## Installing Mithril Signer on Your Block Producer
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/starting-the-nodes.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iii-operation/starting-the-nodes.md
@@ -17,7 +17,7 @@ sudo systemctl start cardano-node
 {% endtabs %}
 
 {% hint style="success" %}
-Congratulations! Your nodes are running successfully. Synchronizing your local copies of the Cardano blockchain ledger with the network may take 24 hours, or more. As of April 2025, the size of the Cardano blockchain ledger is approximately 200 GB. Optionally, to restore and bootstrap a full node rapidly set up a [Mithril Client](https://mithril.network/doc/mithril/advanced/mithril-network/client)
+Congratulations! Your nodes are running successfully. Synchronizing your local copies of the Cardano blockchain ledger with the network may take more than 24 hours. As of August 2025, the size of the Cardano Mainnet blockchain ledger is approximately 215 GB. <!-- Optionally, to restore and bootstrap a full node rapidly set up a [Mithril Client](https://mithril.network/doc/mithril/advanced/mithril-network/client). -->
 {% endhint %}
 
 To monitor your Cardano nodes, install gLiveView. <a href="#gliveview" id="gliveview"></a>

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/claiming-stake-pool-rewards.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/claiming-stake-pool-rewards.md
@@ -43,37 +43,45 @@ echo destinationAddress: $destinationAddress
 {% endtab %}
 {% endtabs %}
 
-Find your payment.addr balance, utxos and build the withdrawal string.
+Retrieve the UTXOs available for your payment address, calculate the balance and build the withdrawal string.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 
 withdrawalString="$(cat stake.addr)+${rewardBalance}"
 ```

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/claiming-stake-pool-rewards.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/claiming-stake-pool-rewards.md
@@ -116,7 +116,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 2 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-representative.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-representative.md
@@ -72,37 +72,45 @@ echo Current Slot: $currentSlot
 {% endtab %}
 {% endtabs %}
 
-Find your balance and **UTXOs**:
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 {% endtab %}
 {% endtabs %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-representative.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-representative.md
@@ -147,7 +147,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 2 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
@@ -22,35 +22,43 @@ currentSlot=$(cardano-cli conway query tip --mainnet | jq -r '.slot')
 echo Current Slot: $currentSlot
 ```
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 
 Find the stakeAddressDeposit value.

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/delegating-to-a-stake-pool.md
@@ -98,7 +98,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 2 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 
@@ -170,35 +170,43 @@ currentSlot=$(cardano-cli conway query tip --mainnet | jq -r '.slot')
 echo Current Slot: $currentSlot
 ```
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 
 Run the build-raw transaction command.
@@ -223,7 +231,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 2 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/retiring-your-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/retiring-your-stake-pool.md
@@ -158,7 +158,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 2 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/retiring-your-stake-pool.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/retiring-your-stake-pool.md
@@ -76,37 +76,45 @@ cardano-cli conway stake-pool deregistration-certificate \
 
 Copy **pool.dereg** to your **hot environment.**
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 {% endtab %}
 {% endtabs %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
@@ -175,7 +175,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 3 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
@@ -99,37 +99,45 @@ echo Current Slot: $currentSlot
 {% endtab %}
 {% endtabs %}
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
-cardano-cli conway query utxo \
-    --address $(cat payment.addr) \
-    --mainnet > fullUtxo.out
+# Retrieve the list of UTXOs available for your payment address
+utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
-tail -n +3 fullUtxo.out | sort -k3 -nr > balance.out
-
-cat balance.out
-
+# Initialize variables
 tx_in=""
 total_balance=0
+txcnt=0
+
+# Loop through the list of UTXOs
 while read -r utxo; do
-    type=$(awk '{ print $6 }' <<< "${utxo}")
-    if [[ ${type} == 'TxOutDatumNone' ]]
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
     then
-        in_addr=$(awk '{ print $1 }' <<< "${utxo}")
-        idx=$(awk '{ print $2 }' <<< "${utxo}")
-        utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
         total_balance=$((${total_balance}+${utxo_balance}))
-        echo TxHash: ${in_addr}#${idx}
-        echo ADA: ${utxo_balance}
-        tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done < balance.out
-txcnt=$(cat balance.out | wc -l)
-echo Total available ADA balance: ${total_balance}
-echo Number of UTXOs: ${txcnt}
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
+
+echo
+echo "Total available ADA balance: ${total_balance}"
+echo "Number of UTXOs: ${txcnt}"
+echo "Final --tx-in string:${tx_in}"
 ```
 {% endtab %}
 {% endtabs %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/updating-stake-pool-information.md
@@ -54,7 +54,7 @@ cardano-cli conway stake-pool registration-certificate \
     --pool-reward-account-verification-key-file stake.vkey \
     --pool-owner-stake-verification-key-file stake.vkey \
     --mainnet \
-    --single-host-pool-relay <dns based relay, example ~ relaynode1.myadapoolnamerocks.com> \
+    --single-host-pool-relay <dns based relay, example ~ relaynode1.pool.example.net> \
     --pool-relay-port 6000 \
     --metadata-url <url where you uploaded poolMetaData.json> \
     --metadata-hash $(cat poolMetaDataHash.txt) \

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-iv-administration/upgrading-a-node.md
@@ -115,8 +115,7 @@ _Table 1 Current Cardano Node Version Requirements_
 
 |     Release Date     | Cardano Node Version | Cardano CLI Version | GHC Version | Cabal Version |
 |  :----------------:  | :------------------: | :-----------------: | :---------: | :-----------: |
-|      April 2025      |        10.3.1        |      10.7.0.0       |    9.6.7    |    3.12.1.0   |
-
+|       July 2025      |        10.5.1        |      10.11.0.0      |    9.6.7    |    3.12.1.0   |
 
 **To upgrade the GHCup installer for GHC and Cabal to the latest version:**
 

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-v-tips/submitting-a-simple-transaction.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-v-tips/submitting-a-simple-transaction.md
@@ -110,7 +110,7 @@ fee=$(cardano-cli conway transaction calculate-min-fee \
     --mainnet \
     --witness-count 1 \
     --byron-witness-count 0 \
-    --protocol-params-file params.json | awk '{ print $1 }')
+    --protocol-params-file params.json | jq -r '.fee')
 echo fee: $fee
 ```
 {% endtab %}

--- a/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-v-tips/submitting-a-simple-transaction.md
+++ b/coins/overview-ada/guide-how-to-build-a-haskell-stakepool-node/part-v-tips/submitting-a-simple-transaction.md
@@ -39,36 +39,45 @@ echo destinationAddress: $destinationAddress
 {% endtab %}
 {% endtabs %}
 
-Find your balance and **UTXOs**.
+Retrieve the UTXOs available for your payment address and calculate the balance.
 
 {% tabs %}
 {% tab title="block producer node" %}
 ```bash
+# Retrieve the list of UTXOs available for your payment address
 utxo_json=$(cardano-cli conway query utxo --address $(cat payment.addr) --mainnet)
 
+# Initialize variables
 tx_in=""
 total_balance=0
 txcnt=0
 
-# Use jq to iterate over all UTXOs
-while read -r txid; do
-    hash=$(cut -d'#' -f1 <<< "$txid")
-    index=$(cut -d'#' -f2 <<< "$txid")
-    amount=$(jq -r --arg txid "$txid" '.[$txid].value.lovelace' <<< "$utxo_json")
-    
-    if [[ "$amount" != "null" && "$amount" -gt 0 ]]; then
-        echo "TxHash: ${hash}#${index}"
-        echo "ADA: ${amount}"
-        tx_in="${tx_in} --tx-in ${hash}#${index}"
-        total_balance=$((total_balance + amount))
-        txcnt=$((txcnt + 1))
+# Loop through the list of UTXOs
+while read -r utxo; do
+    # Retrieve the values for the current UTXO
+    values=$(jq -r --arg k "${utxo}" '.[$k]' <<< "${utxo_json}")
+    # Retrieve datum associated with the UTXO
+    datum=$(jq -r '.datum' <<< "${values}")
+    # Retrieve the reference script associated with the UTXO
+    script=$(jq -r '.referenceScript' <<< "${values}")
+	# If limits on spending the UTXO may exist, then skip the UTXO
+    if [[ ${datum} == 'null' && ${script} == 'null' ]]
+    then
+        hash=${utxo%%#*}
+        idx=${utxo#*#}
+        utxo_balance=$(jq -r '.value.lovelace' <<< "${values}")
+        total_balance=$((${total_balance}+${utxo_balance}))
+        echo "TxHash: ${hash}#${idx}"
+        echo "ADA: ${utxo_balance}"
+        tx_in="${tx_in} --tx-in ${hash}#${idx}"
+		txcnt=$((txcnt + 1))
     fi
-done <<< "$(jq -r 'keys[]' <<< "$utxo_json")"
+done <<< "$(jq -r 'keys[]' <<< "${utxo_json}")"
 
 echo
 echo "Total available ADA balance: ${total_balance}"
 echo "Number of UTXOs: ${txcnt}"
-echo "Final --tx-in string: ${tx_in}"
+echo "Final --tx-in string:${tx_in}"
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The pull request incorporates revisions to support Cardano Node 10.5.1 and Cardano CLI 10.11.0.0, including:

- Updating scripts to parse Cardano CLI JSON output
- Revising the example DNS name used to demonstrate how to register relay nodes
- Fixing minor errors
- Polishing content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Refreshed stake pool guide intro and added producer–relay diagram.
  - Updated version requirements: Cardano Node 10.5.1, Cardano CLI 10.11.0.0.
  - Clarified prerequisites, hardware specs, and Testnet guidance; adjusted storage and ADA requirements.
  - Migrated UTXO workflows to JSON/jq across multiple operations; updated fee extraction.
  - Converted slot-leadership example to JSON.
  - Overhauled Mithril Signer setup and Squid relay configuration.
  - Updated relay domain examples; minor text tweaks and notes.

- Bug Fixes
  - Minor error corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->