### PR TITLE
Update guide-or-how-to-run-a-full-node.md with 2025 blockchain weight

### DIFF
--- a/coins/overview-xmr/guide-or-how-to-run-a-full-node.md
+++ b/coins/overview-xmr/guide-or-how-to-run-a-full-node.md
@@ -26,15 +26,15 @@ Monero nodes come in two flavours.
 
 * Dual-core CPU
 * 4+ GB RAM
-* 160GB+ SSD HD
+* 240GB+ SSD HD
 
 ### :robot: Minimum Pruned Node System Requirements <a href="#minimum-slasher-system-requirements" id="minimum-slasher-system-requirements"></a>
 
 * Same as full node yet with a smaller HD
-* 80GB+ SSD HD
+* 105GB+ SSD HD
 
 {% hint style="info" %}
-As of early 2021, a pruned node uses 32GB and a full node uses 96GB of storage space.
+In 2025, a pruned node uses ~95GB and a full node uses ~230GB of storage space.
 {% endhint %}
 
 ## :bricks: 1. Configuring ports and firewall


### PR DESCRIPTION
The initial information about monero blockchain weight was outdated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated storage requirements for running a full node to reflect current specifications
  * Full node now requires 240GB+ SSD; pruned node requires 105GB+
  * Refreshed guidance with 2025 data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->